### PR TITLE
things that are needed to make 'make doc' work

### DIFF
--- a/mathcomp/Makefile.common
+++ b/mathcomp/Makefile.common
@@ -128,7 +128,7 @@ endif
 %.vo: __always__ Makefile.coq
 	+$(COQMAKE) $@
 
-doc:
+doc: __always__ Makefile.coq
 	mkdir -p _build_doc/
 	cp -r $(COQFILES) -t _build_doc/ --parents
 	cp Make Makefile* _build_doc
@@ -136,7 +136,7 @@ doc:
 	. ../etc/utils/builddoc_lib.sh; \
 		cd _build_doc && mangle_sources $(COQFILES)
 	+cd _build_doc && $(COQMAKE)
-	cd _build_doc && grep -v vio: .Makefile.coq.d > depend
+	cd _build_doc && grep -v vio: .coqdeps.d > depend
 	cd _build_doc && cat depend | ../../etc/buildlibgraph $(COQFILES) > htmldoc/depend.js
 	cd _build_doc && $(COQBIN)coqdoc -t "Mathematical Components" \
 		-g --utf8 -R . mathcomp \

--- a/mathcomp/Makefile.common
+++ b/mathcomp/Makefile.common
@@ -136,7 +136,7 @@ doc: __always__ Makefile.coq
 	. ../etc/utils/builddoc_lib.sh; \
 		cd _build_doc && mangle_sources $(COQFILES)
 	+cd _build_doc && $(COQMAKE)
-	[ ! -f .Makefile.coq.d ] || cp .coqdeps.d .Makefile.coq.d #can be removed when coq-8.10 compatibility is dropped
+	cd _build_doc && if [ ! -f .Makefile.coq.d ] ; then cp .coqdeps.d .Makefile.coq.d ; fi #can be removed when coq-8.10 compatibility is dropped
 	cd _build_doc && grep -v vio: .Makefile.coq.d > depend
 	cd _build_doc && cat depend | ../../etc/buildlibgraph $(COQFILES) > htmldoc/depend.js
 	cd _build_doc && $(COQBIN)coqdoc -t "Mathematical Components" \

--- a/mathcomp/Makefile.common
+++ b/mathcomp/Makefile.common
@@ -136,7 +136,7 @@ doc: __always__ Makefile.coq
 	. ../etc/utils/builddoc_lib.sh; \
 		cd _build_doc && mangle_sources $(COQFILES)
 	+cd _build_doc && $(COQMAKE)
-	[ ! -f .Makefile.coq.d ] || cp .coqdeps.d .Makefile.coq.d
+	[ ! -f .Makefile.coq.d ] || cp .coqdeps.d .Makefile.coq.d #can be removed when coq-8.10 compatibility is dropped
 	cd _build_doc && grep -v vio: .Makefile.coq.d > depend
 	cd _build_doc && cat depend | ../../etc/buildlibgraph $(COQFILES) > htmldoc/depend.js
 	cd _build_doc && $(COQBIN)coqdoc -t "Mathematical Components" \

--- a/mathcomp/Makefile.common
+++ b/mathcomp/Makefile.common
@@ -136,7 +136,8 @@ doc: __always__ Makefile.coq
 	. ../etc/utils/builddoc_lib.sh; \
 		cd _build_doc && mangle_sources $(COQFILES)
 	+cd _build_doc && $(COQMAKE)
-	cd _build_doc && grep -v vio: .coqdeps.d > depend
+	[ ! -f .Makefile.coq.d ] || cp .coqdeps.d .Makefile.coq.d
+	cd _build_doc && grep -v vio: .Makefile.coq.d > depend
 	cd _build_doc && cat depend | ../../etc/buildlibgraph $(COQFILES) > htmldoc/depend.js
 	cd _build_doc && $(COQBIN)coqdoc -t "Mathematical Components" \
 		-g --utf8 -R . mathcomp \


### PR DESCRIPTION
Apparently the dependency files changed name.  This modification takes the change into account, but it is not robust to a future change.